### PR TITLE
Slight optimization to the template

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -6,12 +6,12 @@ ENV MARIADB_VERSION=%%VERSION_FULL%%
 
 USER root
 
-RUN	apt-get update && \
-	apt-key adv --recv-keys \
+RUN	apt-key adv --recv-keys \
 		--keyserver hkp://keyserver.ubuntu.com:80 \
 		0xF1656F24C74CD1D8 && \
 	add-apt-repository "deb http://archive.mariadb.org/mariadb-${MARIADB_VERSION}/repo/ubuntu/ $(lsb_release -sc) main" && \
-	apt-get install mariadb-server gosu
+	apt-get install mariadb-server gosu && \
+	rm -rf /var/lib/apt/lists/*
 
 RUN	rm -rf /var/lib/mysql && \
 	mkdir -p /var/lib/mysql /var/run/mysqld && \
@@ -21,13 +21,13 @@ RUN	rm -rf /var/lib/mysql && \
 		| xargs -0 grep -lZE '^(bind-address|log|user\s)' \
 		| xargs -rt -0 sed -Ei 's/^(bind-address|log|user\s)/#&/' || true
 
-RUN mkdir /docker-entrypoint-initdb.d
-
 COPY docker-entrypoint.sh /usr/local/bin/
-RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 
-RUN chmod +x /usr/local/bin/docker-entrypoint.sh && \
-	chown -R mysql:mysql /usr/local/bin/docker-entrypoint.sh
+# symlink for backwards compatiblity
+RUN ln -s usr/local/bin/docker-entrypoint.sh / && \
+	chmod +x /usr/local/bin/docker-entrypoint.sh && \
+	chown -R mysql:mysql /usr/local/bin/docker-entrypoint.sh && \
+	mariadb --version | grep "${MARIADB_VERSION}"
 
 ENV MYSQL_ROOT_HOST=% \
 	MYSQL_ALLOW_EMPTY_PASSWORD=true \


### PR DESCRIPTION
Very small tweaks for optimization for the template file. There was very little to do as the Dockerfile was already pretty good. With these tweaks and MariaDB v10.6.5 as an example, the image goes from 1.37GB to 1.34GB and 12 layers to 10 layers.

For my changes, I've commented line by line my thought process.