### PR TITLE
Backwards compatible test for 10.3

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -27,7 +27,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 RUN ln -s usr/local/bin/docker-entrypoint.sh / && \
 	chmod +x /usr/local/bin/docker-entrypoint.sh && \
 	chown -R mysql:mysql /usr/local/bin/docker-entrypoint.sh && \
-	mariadb --version | grep "${MARIADB_VERSION}"
+	mysql --version | grep "${MARIADB_VERSION}"
 
 ENV MYSQL_ROOT_HOST=% \
 	MYSQL_ALLOW_EMPTY_PASSWORD=true \


### PR DESCRIPTION
The `mariadb` command only works from `10.4` upwards, so this will fail on `10.3`. The `mysql` command is more universal in this instance