### PR TITLE
Add pwgen for compatibility with MYSQL_RANDOM_ROOT_PASSWORD

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -19,7 +19,7 @@ RUN	apt-key adv --recv-keys \
 		--keyserver hkp://keyserver.ubuntu.com:80 \
 		0xF1656F24C74CD1D8 && \
 	add-apt-repository "deb http://archive.mariadb.org/mariadb-${MARIADB_VERSION}/repo/ubuntu/ $(lsb_release -sc) main" && \
-	apt-get install mariadb-server gosu && \
+	apt-get install mariadb-server gosu pwgen && \
 	rm -rf /var/lib/apt/lists/*
 
 RUN	rm -rf /var/lib/mysql && \


### PR DESCRIPTION
Small update to add the pwgen package to enable compatibility with `MYSQL_RANDOM_ROOT_PASSWORD` option which generates a random root password on spin-up.

This was included in the old `circleci/mysql` image, so it seems fair to add it back to the next-gen image.

Closes #29