### PR TITLE
Add arm64 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,87 +1,26 @@
 version: 2.1
 
 orbs:
-  sonar: hubci/sonar@1.0.0
+  cimg: circleci/cimg@0.3.3
 
 workflows:
-  main:
+  main-wf:
     jobs:
-      - build:
-          context: cimg-publishing
-
-jobs:
-  build:
-    docker:
-      - image: cimg/base:2022.11
-    steps:
-      - checkout
-      - setup_remote_docker:
-          version: "20.10.17"
-      - run:
-          name: "Build Docker Images"
-          command: |
-            ./build-images.sh
-            docker images
-            echo 'export DOCKER_PASS=$DOCKER_TOKEN' >> $BASH_ENV
-      - run:
-          name: "Install Test Prerequisites"
-          command: |
-            sudo apt-get update && \
-            sudo apt-get install -y mysql-client
-      - run:
-          name: "Test Docker Images"
-          shell: /bin/bash -o pipefail
-          command: |
-            ssh -f -N -L localhost:3306:localhost:3306 remote-docker
-            IMAGES=$(docker images --format='{{.Repository}}:{{.Tag}}' | grep "cimg/mariadb")
-            for IMAGE in $IMAGES; do
-              printf "Booting $IMAGE...\n"
-              CONTAINER_ID=$(docker run --rm --env MYSQL_USER=user --env MYSQL_PASSWORD=passw0rd -p 3306:3306 -d $IMAGE)
-              for i in {1..20}; do
-                printf "[$i/20] Checking MariaDB is up...\n"
-                mysqladmin ping -h 127.0.0.1 --silent
-                if [ $? -eq 0 ]; then
-                  printf "Booted $IMAGE!\n"
-                  break
-                elif [ $? -ne 0 ] && [ $i -eq 20 ]; then
-                  printf "Failed to boot image\n"
-                  exit 1
-                fi
-                printf "[$i/20] No response. Sleeping 10s...\n"
-                sleep 10s
-              done
-              printf "Running Version Check...\n"
-              VERSION=$(echo $IMAGE | cut -d ":" -f2 | cut -d "-" -f1)
-              if mysql -h 127.0.0.1 -u user -ppassw0rd --execute="SELECT VERSION();" | grep $VERSION ; then
-                printf "Version matches!\n"
-              else
-                printf "Version mismatch!\n"
-                exit 1
-              fi
-              printf "Stopping $IMAGE...\n"
-              docker stop $CONTAINER_ID >/dev/null 2>&1
-            done
-            printf "All images passed!\n"
-      - deploy:
-          name: "Publish Docker Images (main branch only)"
-          command: |
-            if [ "${CIRCLE_BRANCH}" == "main" ]; then
-              
-              echo $DOCKER_TOKEN | docker login -u $DOCKER_USER --password-stdin
-              
-              # an else block will be added in the future for a staging release
-              if git log -1 --pretty=%s | grep "\[release\]"; then
-                echo "Publishing cimg/mariadb to Docker Hub production."
-                ./push-images.sh
-              else
-                echo "Skipping publishing."
-              fi
-            fi
-      - when:
-          condition:
-            equal: [main, << pipeline.git.branch >>]
-          steps:
-            - sonar/install:
-                version: "0.15.0"
-            - sonar/update-readme:
-                image: cimg/mariadb
+    - cimg/build-and-deploy:
+        name: "Staging"
+        docker-namespace: ccitest
+        docker-repository: mariadb
+        publish-branch: test
+        filters:
+          branches:
+            ignore:
+              - main
+        context: cimg-publishing
+    - cimg/build-and-deploy:
+        name: "Deploy"
+        docker-repository: mariadb
+        filters:
+          branches:
+            only:
+              - main
+        context: cimg-publishing

--- a/manifest
+++ b/manifest
@@ -4,3 +4,4 @@ repository=mariadb
 parent=base
 variants=()
 namespace=cimg
+arm64=1


### PR DESCRIPTION
# Description
This PR adds multi architecture images with arm64 support

# Reasons
Enables arm64 support using the updating tooling in cimg-shared and cimg-orb and arch checks.

Also includes config refactor to use the cimg orb for publishing.

Mariadb 10.4 and 10.5 are still currently supported LTS versions, but packages are not offered for Ubuntu 20.04, so we will only build 10.6 and up moving forward (cimg/base only supports arm64 with 20.04 variants and up)

Test build of all current LTS versions that support 20.04: https://app.circleci.com/pipelines/github/CircleCI-Public/cimg-mariadb/115/workflows/cb4a78b1-6de5-4297-baa1-83378a106405/jobs/126

# Checklist

Please check through the following before opening your PR. Thank you!

- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)