### PR TITLE
feat: add mariadbFeed.sh

### DIFF
--- a/mariadbFeed.sh
+++ b/mariadbFeed.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+vers=()
+
+if [ -f shared/automated-updates.sh ]; then
+  source shared/automated-updates.sh
+else
+  echo "Check if submodule was loaded; automated-updates.sh is missing"
+  exit 1
+fi
+
+
+getMariaDBVersions() {
+  RSS_URL="https://github.com/mariadb/server/tags.atom"
+  VERSIONS=$(curl --silent "$RSS_URL" | grep -E '(title)' | tail -n +2 | sed -e 's/^[ \t]*//' | sed -e 's/<title>//' -e 's/<\/title>//')
+  CLEAN_VERSIONS=$(echo "$VERSIONS" | grep -E "^mariadb-[0-9]+(\.[0-9]+)*$" | cut -d '-' -f2)
+  for newVersion in $CLEAN_VERSIONS; do
+    if ! [[ -d "${newVersion%.*}" ]]; then
+      vers+=("$newVersion")
+      continue
+    fi
+    generateSearchTerms "MARIADB_VERSION=" "${newVersion%.*}"/Dockerfile
+    directoryCheck "${newVersion%.*}" "$SEARCH_TERM"
+    if [[ $(eval echo $?) == 0 ]]; then
+      vers+=("$newVersion")
+    fi
+  done
+}
+
+getMariaDBVersions
+
+if [ -n "${vers[*]}" ]; then
+  echo "Included version updates: ${vers[*]}"
+  echo "Running release script"
+  echo "${vers[*]}"
+  ./shared/release.sh "${vers[@]}"
+else
+  echo "No new version updates"
+  exit 0
+fi


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
A brief description of the changes in this PR.
adds mariadbFeed.sh, which enables automated builds

# Reasons
Please provide reasoning for these changes and how this PR achieves them.
less TOIL

If applicable, include a link to the related GitHub issue that this PR will close.

# Checklist

Please check through the following before opening your PR. Thank you!

- [N/A] I have made changes to the `Dockerfile.template` file only
- [N/A] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
